### PR TITLE
Add pushback speed slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ app.whenReady().then(() => {
 });
 ```
 
-The bridge reads lines like `pushback`, `pushback-stop` and `angle:<radians>` from its standard input. When `pushback` is received, it freezes the aircraft and repeatedly repositions it to simulate a tug. `angle:` adjusts the steering angle while the loop runs, and `pushback-stop` ends the sequence and unfreezes the plane. The implementation lives in `main.cpp`.
+The bridge reads lines like `pushback`, `pushback-stop`, `angle:<radians>` and `speed:<meters>` from its standard input. When `pushback` is received, it freezes the aircraft and repeatedly repositions it to simulate a tug. `angle:` adjusts the steering angle while the loop runs, `speed:` controls how many meters the plane moves on each tick, and `pushback-stop` ends the sequence and unfreezes the plane. The implementation lives in `main.cpp`.
 
 ## Building the bridge from source
 

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,7 @@ HANDLE hSimConnect = NULL;
 HANDLE pushbackThread = NULL;
 volatile bool pushing = false;
 volatile float steerAngle = 0.0f; // radians
+volatile float stepSize = 0.25f; // meters per tick
 
 PlanePosition currentPos{};
 volatile bool posReceived = false;
@@ -68,7 +69,7 @@ DWORD WINAPI pushbackLoop(LPVOID) {
         double metersPerDegLat = 111111.0;
         double metersPerDegLon = 111111.0 * cos(pos.lat * degToRad);
 
-        double step = 0.25; // meters per tick
+        double step = stepSize; // meters per tick
 
         // move backwards along current heading
         double headingRad = (pos.heading + 180.0) * degToRad;
@@ -130,6 +131,10 @@ void runBridge() {
         } else if (strncmp(input, "angle:", 6) == 0) {
             steerAngle = strtof(input + 6, NULL);
             printf("Set steering angle: %.2f radians\n", steerAngle);
+            fflush(stdout);
+        } else if (strncmp(input, "speed:", 6) == 0) {
+            stepSize = strtof(input + 6, NULL);
+            printf("Set pushback speed: %.2f m/tick\n", stepSize);
             fflush(stdout);
         }
     }

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -21,6 +21,10 @@ function updateSteering(value) {
   const radians = (parseFloat(value) * Math.PI) / 180;
   window.api.sendCommand(`angle:${radians.toFixed(4)}`);
 }
+
+function updateSpeed(value) {
+  window.api.sendCommand(`speed:${parseFloat(value).toFixed(2)}`);
+}
 // ...existing code...
 
 window.onload = () => {
@@ -30,6 +34,12 @@ window.onload = () => {
   slider.oninput = (e) => {
     angleValue.textContent = `${slider.value}°`;
     updateSteering(slider.value);
+  };
+  const speedSlider = document.getElementById('slider-speed');
+  const speedValue = document.getElementById('speed-value');
+  speedSlider.oninput = () => {
+    speedValue.textContent = `${speedSlider.value} m/tick`;
+    updateSpeed(speedSlider.value);
   };
   document.getElementById('btn-left').onclick = () => {
     slider.value = -45;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -16,6 +16,10 @@
     <input type="range" id="slider-angle" min="-90" max="90" value="0" />
     <span id="angle-value">0°</span>
 
+    <h3>Pushback Speed</h3>
+    <input type="range" id="slider-speed" min="0.1" max="1" step="0.05" value="0.25" />
+    <span id="speed-value">0.25 m/tick</span>
+
     <h3>Steering Presets</h3>
     <button id="btn-left">Left</button>
     <button id="btn-straight">Straight</button>


### PR DESCRIPTION
## Summary
- allow C++ bridge to adjust pushback speed
- expose new speed slider in UI and forward value to bridge
- document the new `speed:` command

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685af7ca07648321b8d2d1b8f45a4837