### PR TITLE
Fix baggage service event

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ received, it freezes the aircraft and repeatedly repositions it to simulate a
 tug. `angle:` adjusts the steering angle while the loop runs, `speed:` controls
 how fast the aircraft moves (meters per second) during the pushback, and
 `pushback-stop` ends the sequence and unfreezes the plane. You can also send
-`baggage-start` and `baggage-stop` to trigger the baggage trucks. The
-implementation lives in `main.cpp`.
+`baggage-start` and `baggage-stop` to trigger the baggage trucks. These
+commands use the `GROUND_SERVICES_REQUEST` SimConnect event with a parameter of
+`3` to request baggage handling. The implementation lives in `main.cpp`.
 
 ## Building the bridge from source
 

--- a/main.cpp
+++ b/main.cpp
@@ -140,7 +140,9 @@ void runBridge() {
     SimConnect_AddToDataDefinition(hSimConnect, DEFINE_POSITION, "PLANE HEADING DEGREES TRUE", "degrees");
     SimConnect_AddToDataDefinition(hSimConnect, DEFINE_TITLE, "TITLE", NULL, SIMCONNECT_DATATYPE_STRING256);
 
-    SimConnect_MapClientEventToSimEvent(hSimConnect, EVENT_BAGGAGE, "TOGGLE_AIRPORT_GROUND_SERVICES");
+    // Use the dedicated ground service request event. The dwData parameter of 3
+    // specifically requests baggage handling trucks.
+    SimConnect_MapClientEventToSimEvent(hSimConnect, EVENT_BAGGAGE, "GROUND_SERVICES_REQUEST");
 
     char input[128];
     while (fgets(input, sizeof(input), stdin)) {
@@ -172,7 +174,9 @@ void runBridge() {
             requestAircraftTitle();
             printf("Baggage service requested for %s\n", aircraftTitle);
             fflush(stdout);
-            SimConnect_TransmitClientEvent(hSimConnect, SIMCONNECT_OBJECT_ID_USER, EVENT_BAGGAGE, 0, SIMCONNECT_GROUP_PRIORITY_HIGHEST, SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY);
+            // Parameter 3 triggers the baggage service according to the MSFS
+            // ground service request definitions.
+            SimConnect_TransmitClientEvent(hSimConnect, SIMCONNECT_OBJECT_ID_USER, EVENT_BAGGAGE, 3, SIMCONNECT_GROUP_PRIORITY_HIGHEST, SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY);
         } else if (strncmp(input, "baggage-stop", 12) == 0) {
             printf("Baggage service stopped\n");
             fflush(stdout);


### PR DESCRIPTION
## Summary
- update README to note baggage event details
- map baggage command to `GROUND_SERVICES_REQUEST`
- send parameter 3 when requesting baggage service

## Testing
- `npm install`
- `npm start` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685b5c641af88321b5cefafaede10de2